### PR TITLE
Fix SearchRequest scope property

### DIFF
--- a/lib/messages/search-request.js
+++ b/lib/messages/search-request.js
@@ -284,21 +284,15 @@ class SearchRequest extends LdapMessage {
   }
 
   /**
-   * The current search scope value.
+   * The current search scope value. Can be matched against the exported
+   * scope statics.
    *
-   * @returns {string}
+   * @returns {number}
    *
    * @throws When the scope is set to an unrecognized scope constant.
    */
   get scope () {
-    switch (this.#scope) {
-      case search.SCOPE_BASE_OBJECT:
-        return 'base'
-      case search.SCOPE_ONE_LEVEL:
-        return 'single'
-      case search.SCOPE_SUBTREE:
-        return 'subtree'
-    }
+    return this.#scope
   }
 
   /**
@@ -316,6 +310,24 @@ class SearchRequest extends LdapMessage {
       throw Error(value + ' is an invalid search scope')
     }
     this.#scope = resolvedScope
+  }
+
+  /**
+   * The current search scope value as a string name.
+   *
+   * @returns {string} One of 'base', 'single', or 'subtree'.
+   *
+   * @throws When the scope is set to an unrecognized scope constant.
+   */
+  get scopeName () {
+    switch (this.#scope) {
+      case search.SCOPE_BASE_OBJECT:
+        return 'base'
+      case search.SCOPE_ONE_LEVEL:
+        return 'single'
+      case search.SCOPE_SUBTREE:
+        return 'subtree'
+    }
   }
 
   /**
@@ -424,7 +436,7 @@ class SearchRequest extends LdapMessage {
    */
   _pojo (obj = {}) {
     obj.baseObject = this.baseObject.toString()
-    obj.scope = this.scope
+    obj.scope = this.scopeName
     obj.derefAliases = this.derefAliases
     obj.sizeLimit = this.sizeLimit
     obj.timeLimit = this.timeLimit

--- a/lib/messages/search-request.test.js
+++ b/lib/messages/search-request.test.js
@@ -186,19 +186,24 @@ tap.test('.filter', t => {
 tap.test('.scope', t => {
   t.test('sets/gets', async t => {
     const req = new SearchRequest()
-    t.equal(req.scope, 'base')
+    t.equal(req.scopeName, 'base')
+    t.equal(req.scope, 0)
 
     req.scope = SearchRequest.SCOPE_SINGLE
-    t.equal(req.scope, 'single')
+    t.equal(req.scopeName, 'single')
+    t.equal(req.scope, 1)
 
     req.scope = SearchRequest.SCOPE_SUBTREE
-    t.equal(req.scope, 'subtree')
+    t.equal(req.scopeName, 'subtree')
+    t.equal(req.scope, 2)
 
     req.scope = 'SUB'
-    t.equal(req.scope, 'subtree')
+    t.equal(req.scopeName, 'subtree')
+    t.equal(req.scope, 2)
 
     req.scope = 'base'
-    t.equal(req.scope, 'base')
+    t.equal(req.scopeName, 'base')
+    t.equal(req.scope, 0)
   })
 
   t.test('throws for invalid value', async t => {


### PR DESCRIPTION
The `.scope` property should not return a name. It should return the actual code so that it can be compared against the RFC defined integers for scopes. We replicated the original implementation without understanding how it was used. This was incorrect.

We also add a `.scopeName` property so that the name can be retrieved if desired.