### PR TITLE
Allow single character attribute names

### DIFF
--- a/lib/messages/search-request.js
+++ b/lib/messages/search-request.js
@@ -34,7 +34,7 @@ const isValidAttributeString = str => {
     return true
   }
   // ascii attribute names
-  if (/^[a-zA-Z][\w\d.;-]+$/.test(str) === true) {
+  if (/^[a-zA-Z][\w\d.;-]*$/.test(str) === true) {
     return true
   }
   return false

--- a/lib/messages/search-request.test.js
+++ b/lib/messages/search-request.test.js
@@ -100,6 +100,13 @@ tap.test('.attributes', t => {
     )
   })
 
+  t.test('supports single character names (issue #2)', async t => {
+    const req = new SearchRequest({
+      attributes: ['a']
+    })
+    t.strictSame(req.attributes, ['a'])
+  })
+
   t.end()
 })
 


### PR DESCRIPTION
This resolves issue #2.

The `isValidAttributeString` function validates search attributes as defined in https://www.rfc-editor.org/rfc/rfc4511#section-4.5.1.8. In particular, the issue described is around the `attributedescription` component defined by https://www.rfc-editor.org/rfc/rfc4512#section-2.5. Specifically an `attributype` of the `oid` variant.

OIDs are described in https://www.rfc-editor.org/rfc/rfc4512#section-1.4 as being a `desc => keystring => leadkeychar *keychar`. With `leadkeychar` being an `ALPHA` character, and `keychar` being `ALPHA`, `DIGIT`, and/or `HYPHEN`.

The miss here is that `*keychar` means "zero or more keychars", not "one or more keychars".