### PR TITLE
skip attribute with empty name

### DIFF
--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -11,4 +11,6 @@ warning.create(clazz, 'LDAP_MESSAGE_DEP_003', 'abandonID is deprecated. Use aban
 
 warning.create(clazz, 'LDAP_MESSAGE_DEP_004', 'errorMessage is deprecated. Use diagnosticMessage instead.')
 
+warning.create(clazz, 'LDAP_ATTRIBUTE_SPEC_ERR_001', 'received attempt to define attribute with an empty name: attribute skipped.')
+
 module.exports = warning

--- a/lib/deprecations.js
+++ b/lib/deprecations.js
@@ -11,6 +11,6 @@ warning.create(clazz, 'LDAP_MESSAGE_DEP_003', 'abandonID is deprecated. Use aban
 
 warning.create(clazz, 'LDAP_MESSAGE_DEP_004', 'errorMessage is deprecated. Use diagnosticMessage instead.')
 
-warning.create(clazz, 'LDAP_ATTRIBUTE_SPEC_ERR_001', 'received attempt to define attribute with an empty name: attribute skipped.')
+warning.create(clazz, 'LDAP_ATTRIBUTE_SPEC_ERR_001', 'received attempt to define attribute with an empty name: attribute skipped.', { unlimited: true })
 
 module.exports = warning

--- a/lib/messages/search-request.js
+++ b/lib/messages/search-request.js
@@ -5,6 +5,7 @@ const { operations, search } = require('@ldapjs/protocol')
 const { DN } = require('@ldapjs/dn')
 const filter = require('@ldapjs/filter')
 const { BerReader, BerTypes } = require('@ldapjs/asn1')
+const warning = require('../deprecations')
 
 const recognizedScopes = new Map([
   ['base', [search.SCOPE_BASE_OBJECT, 'base']],
@@ -198,6 +199,9 @@ class SearchRequest extends LdapMessage {
     for (const attr of attrs) {
       if (typeof attr === 'string' && isValidAttributeString(attr) === true) {
         newAttrs.push(attr)
+      } else if (typeof attr === 'string' && attr === '') {
+        // TODO: emit warning about spec violation via log and/or telemetry
+        warning.emit('LDAP_ATTRIBUTE_SPEC_ERR_001')
       } else {
         throw Error('attribute must be a valid string')
       }

--- a/lib/messages/search-request.test.js
+++ b/lib/messages/search-request.test.js
@@ -6,6 +6,10 @@ const filter = require('@ldapjs/filter')
 const SearchRequest = require('./search-request')
 const { DN } = require('@ldapjs/dn')
 const { BerReader, BerWriter } = require('@ldapjs/asn1')
+const warning = require('../deprecations')
+
+// Silence the standard warning logs. We will test the messages explicitly.
+process.removeAllListeners('warning')
 
 const {
   searchRequestBytes
@@ -105,6 +109,24 @@ tap.test('.attributes', t => {
       attributes: ['a']
     })
     t.strictSame(req.attributes, ['a'])
+  })
+
+  t.test('skip empty attribute name', async t => {
+    process.on('warning', handler)
+    t.teardown(async () => {
+      process.removeListener('warning', handler)
+      warning.emitted.set('LDAP_ATTRIBUTE_SPEC_ERR_001', false)
+    })
+
+    const req = new SearchRequest({
+      attributes: ['abc', '']
+    })
+    t.strictSame(req.attributes, ['abc'])
+
+    function handler (error) {
+      t.equal(error.message, 'received attempt to define attribute with an empty name: attribute skipped.')
+      t.end()
+    }
   })
 
   t.end()

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@ldapjs/dn": "1.0.0",
     "@ldapjs/filter": "2.0.0",
     "@ldapjs/protocol": "1.2.1",
-    "process-warning": "^2.1.0"
+    "process-warning": "^2.2.0"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.0.2",


### PR DESCRIPTION
This should resolve [#867](https://github.com/ldapjs/node-ldapjs/issues/867).

The `search-request.js` file has been changed so that empty attribute names are skipped while a corresponding warning is emitted.