### PR TITLE
Allow for AD range attribute option

### DIFF
--- a/lib/messages/search-request.js
+++ b/lib/messages/search-request.js
@@ -34,7 +34,14 @@ const isValidAttributeString = str => {
   if (/^@[a-zA-Z][\w\d.-]*$/.test(str) === true) {
     return true
   }
-  // ascii attribute names
+  /**
+  * ascii attribute names
+  *
+  * Validation inclusion of (=) and (*) characters supports the non-standard
+  * `range=<low>-<high>` ActiveDirectory extension as described in
+  * §3.1.1.3.1.3.3 (revision 57.0) of
+  * https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/d2435927-0999-4c62-8c6d-13ba31a52e1a.
+  */
   if (/^[a-zA-Z][\w\d.;=*-]*$/.test(str) === true) {
     return true
   }

--- a/lib/messages/search-request.js
+++ b/lib/messages/search-request.js
@@ -35,7 +35,7 @@ const isValidAttributeString = str => {
     return true
   }
   // ascii attribute names
-  if (/^[a-zA-Z][\w\d.;-]*$/.test(str) === true) {
+  if (/^[a-zA-Z][\w\d.;=*-]*$/.test(str) === true) {
     return true
   }
   return false

--- a/lib/messages/search-request.js
+++ b/lib/messages/search-request.js
@@ -34,15 +34,14 @@ const isValidAttributeString = str => {
   if (/^@[a-zA-Z][\w\d.-]*$/.test(str) === true) {
     return true
   }
-  /**
-  * ascii attribute names
-  *
-  * Validation inclusion of (=) and (*) characters supports the non-standard
-  * `range=<low>-<high>` ActiveDirectory extension as described in
-  * §3.1.1.3.1.3.3 (revision 57.0) of
-  * https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/d2435927-0999-4c62-8c6d-13ba31a52e1a.
-  */
-  if (/^[a-zA-Z][\w\d.;=*-]*$/.test(str) === true) {
+  // ascii attribute names per RFC 4512 §2.5
+  if (/^[a-zA-Z][\w\d.;-]*$/.test(str) === true) {
+    return true
+  }
+  // Matches the non-standard `range=<low>-<high>` ActiveDirectory
+  // extension as described in §3.1.1.3.1.3.3 (revision 57.0) of
+  // https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/d2435927-0999-4c62-8c6d-13ba31a52e1a.
+  if (/^[a-zA-Z][\w\d.-]*(;[\w\d.-]+)*;range=\d+-(\d+|\*)(;[\w\d.-]+)*$/.test(str) === true) {
     return true
   }
   return false

--- a/lib/messages/search-request.test.js
+++ b/lib/messages/search-request.test.js
@@ -111,11 +111,38 @@ tap.test('.attributes', t => {
     t.strictSame(req.attributes, ['a'])
   })
 
+  t.test('supports multiple attribute options', async t => {
+    const req = new SearchRequest({
+      attributes: ['abc;lang-en;lang-es']
+    })
+    t.strictSame(req.attributes, ['abc;lang-en;lang-es'])
+  })
+
   t.test('supports range options', async t => {
     const req = new SearchRequest({
-      attributes: ['a;range=0-*']
+      attributes: [
+        'a;range=0-*',
+        'abc;range=100-200',
+        'def;range=0-5;lang-en',
+        'ghi;lang-en;range=6-10',
+        'jkl;lang-en;range=11-15;lang-es'
+      ]
     })
-    t.strictSame(req.attributes, ['a;range=0-*'])
+    t.strictSame(req.attributes, [
+      'a;range=0-*',
+      'abc;range=100-200',
+      'def;range=0-5;lang-en',
+      'ghi;lang-en;range=6-10',
+      'jkl;lang-en;range=11-15;lang-es'
+    ])
+  })
+
+  t.test('throws if array contains an invalid range', async t => {
+    const input = ['a;range=*-100']
+    t.throws(
+      () => new SearchRequest({ attributes: input }),
+      'attribute must be a valid string'
+    )
   })
 
   t.test('skip empty attribute name', async t => {

--- a/lib/messages/search-request.test.js
+++ b/lib/messages/search-request.test.js
@@ -111,6 +111,13 @@ tap.test('.attributes', t => {
     t.strictSame(req.attributes, ['a'])
   })
 
+  t.test('supports range options', async t => {
+    const req = new SearchRequest({
+      attributes: ['a;range=0-*']
+    })
+    t.strictSame(req.attributes, ['a;range=0-*'])
+  })
+
   t.test('skip empty attribute name', async t => {
     process.on('warning', handler)
     t.teardown(async () => {


### PR DESCRIPTION
I would like to loosen up the restriction on characters allowed for attributes, so that the message library does not error out when passing Active Directory range options. I've tested this change out on our AD service and was able to retrieve lists with limited range sets. This attribute option is necessary for our application, as our AD service is setup to limit the amount of members returned among other group listings.